### PR TITLE
Updates Pacakge Task For Local Runs

### DIFF
--- a/build/PackageTask.cs
+++ b/build/PackageTask.cs
@@ -1,4 +1,6 @@
 
+using Cake.Common.Build;
+
 namespace BuildScripts;
 
 [TaskName("Package")]
@@ -12,8 +14,16 @@ public sealed class PackageTask : FrostingTask<BuildContext>
         var patch = context.FindRegexMatchGroupInFile("freeimage/FreeImage.rc", regex, 2, System.Text.RegularExpressions.RegexOptions.Singleline);
         var version = $"{major}.{minor}.{patch}";
         var dnMsBuildSettings = new DotNetMSBuildSettings();
-        dnMsBuildSettings.WithProperty("Version", version + "." + context.EnvironmentVariable("GITHUB_RUN_NUMBER"));
-        dnMsBuildSettings.WithProperty("RepositoryUrl", "https://github.com/" + context.EnvironmentVariable("GITHUB_REPOSITORY"));
+
+        if (context.BuildSystem().IsRunningOnGitHubActions)
+        {
+            dnMsBuildSettings.WithProperty("Version", version + "." + context.EnvironmentVariable("GITHUB_RUN_NUMBER"));
+            dnMsBuildSettings.WithProperty("RepositoryUrl", "https://github.com/" + context.EnvironmentVariable("GITHUB_REPOSITORY"));
+        }
+        else
+        {
+            dnMsBuildSettings.WithProperty("Version", version);
+        }
 
         var dnPackSettings = new DotNetPackSettings
         {


### PR DESCRIPTION
This PR updates the Package build task so that it can be run locally.  Before this it would fail due to the `context.EnvironmentVariable("GITHUB_RUN_NUMBER")` being unavailable locally which creates an invalid version number.