### PR TITLE
Added arm64 Windows build output for FreeImage dependency

### DIFF
--- a/build/BuildWindowsTask.cs
+++ b/build/BuildWindowsTask.cs
@@ -24,7 +24,7 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
             Configuration = "Release",
             PlatformTarget = PlatformTarget.x64
         };
-        buildSettingsx64.WithProperty("WindowsTargetPlatformVersion", "10.0.22621.0");
+        buildSettingsx64.WithProperty("WindowsTargetPlatformVersion", "10.0.17763.0");
         buildSettingsx64.WithProperty("PlatformToolset", "v143");
         context.MSBuild("freeimage/FreeImage.2017.sln", buildSettingsx64);
         context.CopyFile("freeimage/Dist/x64/Freeimage.dll", $"{context.ArtifactsDir}/FreeImage.dll");
@@ -35,7 +35,7 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
             Configuration = "Release",
             PlatformTarget = PlatformTarget.ARM64
         };
-        buildSettingsarm64.WithProperty("WindowsTargetPlatformVersion", "10.0.22621.0");
+        buildSettingsarm64.WithProperty("WindowsTargetPlatformVersion", "10.0.17763.0");
         buildSettingsarm64.WithProperty("PlatformToolset", "v143");
         context.MSBuild("freeimage/FreeImage.2017.sln", buildSettingsarm64);
         context.CopyFile("freeimage/Dist/arm64/Freeimage.dll", $"{context.ArtifactsDir}/FreeImage.dll");

--- a/build/BuildWindowsTask.cs
+++ b/build/BuildWindowsTask.cs
@@ -27,7 +27,8 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
         buildSettingsx64.WithProperty("WindowsTargetPlatformVersion", "10.0.17763.0");
         buildSettingsx64.WithProperty("PlatformToolset", "v143");
         context.MSBuild("freeimage/FreeImage.2017.sln", buildSettingsx64);
-        context.CopyFile("freeimage/Dist/x64/Freeimage.dll", $"{context.ArtifactsDir}/FreeImage.dll");
+        context.CreateDirectory($"{context.ArtifactsDir}/x64");
+        context.CopyFile("freeimage/Dist/x64/Freeimage.dll", $"{context.ArtifactsDir}/x64/FreeImage.dll");
 
         MSBuildSettings buildSettingsarm64 = new()
         {
@@ -38,6 +39,7 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
         buildSettingsarm64.WithProperty("WindowsTargetPlatformVersion", "10.0.17763.0");
         buildSettingsarm64.WithProperty("PlatformToolset", "v143");
         context.MSBuild("freeimage/FreeImage.2017.sln", buildSettingsarm64);
-        context.CopyFile("freeimage/Dist/arm64/Freeimage.dll", $"{context.ArtifactsDir}/FreeImage.dll");
+        context.CreateDirectory($"{context.ArtifactsDir}/arm64");
+        context.CopyFile("freeimage/Dist/arm64/Freeimage.dll", $"{context.ArtifactsDir}/arm64/FreeImage.dll");
     }
 }

--- a/build/BuildWindowsTask.cs
+++ b/build/BuildWindowsTask.cs
@@ -18,15 +18,26 @@ public sealed class BuildWindowsTask : FrostingTask<BuildContext>
         context.ReplaceTextInFiles("freeimage/Source/OpenEXR/IlmImf/ImfAttribute.cpp", "std::binary_function", "binary_function");
         context.ReplaceRegexInFiles("freeimage/Source/OpenEXR/IlmImf/ImfAttribute.cpp", "namespace {.*", "namespace { template<class Arg1, class Arg2, class Result> struct binary_function { using first_argument_type = Arg1; using second_argument_type = Arg2; using result_type = Result; };");
 
-        MSBuildSettings buildSettings = new()
+        MSBuildSettings buildSettingsx64 = new()
         {
             Verbosity = Verbosity.Normal,
             Configuration = "Release",
             PlatformTarget = PlatformTarget.x64
         };
-        buildSettings.WithProperty("WindowsTargetPlatformVersion", "10.0.17763.0");
-        buildSettings.WithProperty("PlatformToolset", "v143");
-        context.MSBuild("freeimage/FreeImage.2017.sln", buildSettings);
+        buildSettingsx64.WithProperty("WindowsTargetPlatformVersion", "10.0.22621.0");
+        buildSettingsx64.WithProperty("PlatformToolset", "v143");
+        context.MSBuild("freeimage/FreeImage.2017.sln", buildSettingsx64);
         context.CopyFile("freeimage/Dist/x64/Freeimage.dll", $"{context.ArtifactsDir}/FreeImage.dll");
+
+        MSBuildSettings buildSettingsarm64 = new()
+        {
+            Verbosity = Verbosity.Normal,
+            Configuration = "Release",
+            PlatformTarget = PlatformTarget.ARM64
+        };
+        buildSettingsarm64.WithProperty("WindowsTargetPlatformVersion", "10.0.22621.0");
+        buildSettingsarm64.WithProperty("PlatformToolset", "v143");
+        context.MSBuild("freeimage/FreeImage.2017.sln", buildSettingsarm64);
+        context.CopyFile("freeimage/Dist/arm64/Freeimage.dll", $"{context.ArtifactsDir}/FreeImage.dll");
     }
 }


### PR DESCRIPTION
FreeImage is used by the mgcb task to pack images into xnb content packages. It doesn't currently support arm64, which means that some notebook computers (GalaxyBook, some recent Surface products, etc.) aren't able to build MonoGame projects. This PR adds arm64 support for the FreeImage dependency, which is one step in the road to supporting these devices.

## Added an arm64 configuration to the freeimage submodule

I added an arm64 configuration to the vs2017 solution and project files. for The build rules were copied verbatim from the x64, except that `RandomizedBaseAddress` had to be set to true as arm64 doesn't support otherwise. Additionally, I had to change the `#define` check in infsimd.h to avoid including mmintrin.h on arm64, and it's not supported.

## Added an arm64 output to BuildWindowsTask.cs

I modified BuildWindowsTask.cs to create an additional build output for arm64. The previous x64 DLL is now copied to a subfolder, which will be a slight compatibility break. Let me know if there's a better way to d othis.

## Testing

I have verified that if I manually copy the arm64 FreeImage.dll built with these changes into a local copy of the dotnet-mgcb package, I the mgcb task builds a content pack containing images on my GalaxyBook. Additionally, I have verified that it continues to produce the same output in its x64 folder after the change as it did before.

## Expected Impact

There will not be any end-product features enabled by this PR alone. The remaining work is:

- Ensure all other mgcb dependencies (e.g. for music, sounds, spritefonts) also build arm64 outputs.
- Modify dotnet-mgcb to be the architecture-aware and use the right dependencies.

After that, it will be possible to build (but not modify) mgcb files on arm64 devices.